### PR TITLE
fix: wrap iOS function with MainActor to avoid crashes on iOS 26+

### DIFF
--- a/keyboard_insets/CHANGELOG.md
+++ b/keyboard_insets/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.2
+[keyboard_insets_mobile] - Use Swift concurrency @MainActor for public C entry points to avoid crashes on iOS 26
+
+## 0.1.1
+[keyboard_insets_mobile] - Fixed a bug with triggering the keyboard observer in JNI.
+[keyboard_insets_mobile] - Fixed the safe area bottom padding exceeding the native Flutter padding on Android.
+
 ## 0.1.0+1
 [Docs] Fixed README.md file columns.
 

--- a/keyboard_insets/README.md
+++ b/keyboard_insets/README.md
@@ -17,7 +17,7 @@ Unlike `MediaQuery.viewInsets`, this package gives you **frame-by-frame updates*
 Add the package to your `pubspec.yaml`:
 ```yaml
 dependencies:
-    keyboard_insets: ^0.1.0
+    keyboard_insets: ^0.1.2
 ```
 
 ### iOS Setup

--- a/keyboard_insets/pubspec.yaml
+++ b/keyboard_insets/pubspec.yaml
@@ -1,6 +1,6 @@
 name: keyboard_insets
 description: A Flutter plugin that provides real-time keyboard height and visibility state across platforms.
-version: 0.1.1
+version: 0.1.2
 
 repository: https://github.com/urbi-ae/keyboard_insets
 homepage: https://github.com/urbi-ae/keyboard_insets
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   keyboard_insets_platform_interface: 1.0.0
-  keyboard_insets_mobile: 0.1.1
+  keyboard_insets_mobile: 0.1.2
   keyboard_insets_web: 0.1.1
 
 flutter:

--- a/keyboard_insets_mobile/CHANGELOG.md
+++ b/keyboard_insets_mobile/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.2
+[iOS] - Use Swift concurrency @MainActor for public C entry points to avoid crashes on iOS 26
+
 ## 0.1.1
 [Android] - Fixed a bug with triggering the keyboard observer in JNI.
 [Android] - Fixed the safe area bottom padding exceeding the native Flutter padding.

--- a/keyboard_insets_mobile/android/src/main/jni/keyboard_insets_jni.c
+++ b/keyboard_insets_mobile/android/src/main/jni/keyboard_insets_jni.c
@@ -11,6 +11,7 @@ static jmethodID g_midSetAnimateKeyboard  = NULL;       // setKeyboardAnimation(
 static jmethodID g_midStartSafeAreaObserver = NULL;     // startSafeAreaObserver()V
 static jmethodID g_midStopSafeAreaObserver  = NULL;     // stopSafeAreaObserver()V
 
+void set_inset_listen(bool value);
 void platform_update_inset(float inset, float target);
 void platform_update_safe_area(float inset);
 
@@ -93,6 +94,7 @@ void stop_listening_insets(void) {
     JNIEnv* env = get_env();
     if (!env) return;
     (*env)->CallStaticVoidMethod(env, g_keyboardClass, g_midStopKeyboardObserver);
+    set_inset_listen(false);
 }
 
 __attribute__((visibility("default")))

--- a/keyboard_insets_mobile/ios/Classes/KeyboardInsetsMobilePlugin.swift
+++ b/keyboard_insets_mobile/ios/Classes/KeyboardInsetsMobilePlugin.swift
@@ -82,16 +82,7 @@ private func _startKeyboardObserverMain() {
         let layer = CALayer()
         layer.position = .zero
 
-        if let window = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first?.windows.first(where: { $0.isKeyWindow })
-        {
-            window.layer.addSublayer(layer)
-        } else if let window = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .flatMap({ $0.windows })
-            .first
-        {
+        if let window = currentWindow() {
             window.layer.addSublayer(layer)
         }
 
@@ -111,7 +102,14 @@ private func _startKeyboardObserverMain() {
             target: DisplayLinkProxy.shared,
             selector: #selector(DisplayLinkProxy.tick(_:))
         )
-        displayLink?.preferredFramesPerSecond = 120
+
+        let maxFPS: Int
+        if #available(iOS 15.0, *) {
+            maxFPS = UIScreen.main.maximumFramesPerSecond
+        } else {
+            maxFPS = 60
+        }
+        displayLink?.preferredFramesPerSecond = maxFPS
         displayLink?.add(to: .main, forMode: .common)
 
         let workItem = DispatchWorkItem { [weak layer] in
@@ -133,8 +131,8 @@ private func _startKeyboardObserverMain() {
 
 @MainActor
 private func _stopKeyboardObserverMain() {
-    if let token = keyboardObserver {
-        NotificationCenter.default.removeObserver(token)
+    if let observer = keyboardObserver {
+        NotificationCenter.default.removeObserver(observer)
         keyboardObserver = nil
     }
 
@@ -147,6 +145,25 @@ private func _stopKeyboardObserverMain() {
 
     settleWorkItem?.cancel()
     settleWorkItem = nil
+}
+
+@MainActor
+func currentWindow() -> UIWindow? {
+    let scene = UIApplication.shared.connectedScenes
+        .compactMap { $0 as? UIWindowScene }
+        .first { $0.activationState == .foregroundActive }
+
+    guard let windowScene = scene else {
+        return nil
+    }
+
+    if let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
+        return keyWindow
+    }
+
+    return windowScene.windows.first {
+        $0.windowLevel == .normal && !$0.isHidden && $0.alpha > 0
+    }
 }
 
 private class DisplayLinkProxy {
@@ -184,9 +201,7 @@ public func stop_safe_area_observer() {
 @MainActor
 private func _startSafeAreaObserverMain() {
     guard
-        let scene = UIApplication.shared.connectedScenes.first
-            as? UIWindowScene,
-        let window = scene.windows.first(where: { $0.isKeyWindow })
+        let window = currentWindow()
     else {
         return
     }
@@ -274,7 +289,7 @@ final class SafeAreaMonitorView: UIView {
 
     private func registerForOrientationChanges() {
         let nc = NotificationCenter.default
-        orientationObserverToken = nc.addObserver(
+        orientationObserver = nc.addObserver(
             forName: UIDevice.orientationDidChangeNotification,
             object: nil,
             queue: .main
@@ -282,7 +297,7 @@ final class SafeAreaMonitorView: UIView {
             self?.handleOrientationChange()
         }
 
-        statusBarObserverToken = nc.addObserver(
+        statusBarObserver = nc.addObserver(
             forName: UIApplication.didChangeStatusBarFrameNotification,
             object: nil,
             queue: .main

--- a/keyboard_insets_mobile/ios/Classes/KeyboardInsetsMobilePlugin.swift
+++ b/keyboard_insets_mobile/ios/Classes/KeyboardInsetsMobilePlugin.swift
@@ -25,6 +25,20 @@ public func simulate_keyboard_animation(_ isEnabled: Bool) {
 
 @_cdecl("start_keyboard_observer")
 public func start_keyboard_observer() {
+    Task { @MainActor in
+        _startKeyboardObserverMain()
+    }
+}
+
+@_cdecl("stop_keyboard_observer")
+public func stop_keyboard_observer() {
+    Task { @MainActor in
+        _stopKeyboardObserverMain()
+    }
+}
+
+@MainActor
+private func _startKeyboardObserverMain() {
     if let observer = keyboardObserver {
         NotificationCenter.default.removeObserver(observer)
         keyboardObserver = nil
@@ -35,12 +49,16 @@ public func start_keyboard_observer() {
         object: nil,
         queue: .main
     ) { note in
-        guard let frameValue = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
+        guard
+            let frameValue = note.userInfo?[
+                UIResponder.keyboardFrameEndUserInfoKey
+            ] as? NSValue
         else { return }
         let frame = frameValue.cgRectValue
         let screenHeight = UIScreen.main.bounds.height
         let animationDuration =
-            (note.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?
+            (note.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey]
+            as? NSNumber)?
             .doubleValue ?? 0.25
 
         startInset = CGFloat(currentInset)
@@ -54,16 +72,26 @@ public func start_keyboard_observer() {
 
         // Cancel old animation + cleanup
         displayLink?.invalidate()
+        displayLink = nil
         animationLayer?.removeAllAnimations()
         animationLayer?.removeFromSuperlayer()
-        displayLink = nil
         animationLayer = nil
         settleWorkItem?.cancel()
+        settleWorkItem = nil
 
         let layer = CALayer()
         layer.position = .zero
 
-        if let window = UIApplication.shared.windows.first {
+        if let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first?.windows.first(where: { $0.isKeyWindow })
+        {
+            window.layer.addSublayer(layer)
+        } else if let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first
+        {
             window.layer.addSublayer(layer)
         }
 
@@ -81,109 +109,131 @@ public func start_keyboard_observer() {
 
         displayLink = CADisplayLink(
             target: DisplayLinkProxy.shared,
-            selector: #selector(DisplayLinkProxy.tick))
+            selector: #selector(DisplayLinkProxy.tick(_:))
+        )
         displayLink?.preferredFramesPerSecond = 120
         displayLink?.add(to: .main, forMode: .common)
 
-        let workItem = DispatchWorkItem {
+        let workItem = DispatchWorkItem { [weak layer] in
             currentInset = Float(targetInset)
             platform_update_inset(currentInset, Float(targetInset))
             displayLink?.invalidate()
-            animationLayer?.removeFromSuperlayer()
             displayLink = nil
+            layer?.removeFromSuperlayer()
             animationLayer = nil
             settleWorkItem = nil
         }
         settleWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration, execute: workItem)
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + animationDuration,
+            execute: workItem
+        )
     }
+}
+
+@MainActor
+private func _stopKeyboardObserverMain() {
+    if let token = keyboardObserver {
+        NotificationCenter.default.removeObserver(token)
+        keyboardObserver = nil
+    }
+
+    displayLink?.invalidate()
+    displayLink = nil
+
+    animationLayer?.removeAllAnimations()
+    animationLayer?.removeFromSuperlayer()
+    animationLayer = nil
+
+    settleWorkItem?.cancel()
+    settleWorkItem = nil
 }
 
 private class DisplayLinkProxy {
     static let shared = DisplayLinkProxy()
 
-    @objc func tick(link: CADisplayLink) {
+    @objc func tick(_ link: CADisplayLink) {
         guard let animLayer = animationLayer,
             let pres = animLayer.presentation(),
-            let t = pres.value(forKeyPath: "position.y") as? CGFloat
+            let tNumber = pres.value(forKeyPath: "position.y") as? NSNumber
         else {
             return
         }
 
+        let t = CGFloat(truncating: tNumber)
         let interpolated = startInset + (targetInset - startInset) * t
         currentInset = Float(interpolated)
         platform_update_inset(Float(currentInset), Float(targetInset))
     }
 }
 
-@_cdecl("stop_keyboard_observer")
-public func stop_keyboard_observer() {
-    if let observer = keyboardObserver {
-        NotificationCenter.default.removeObserver(observer)
-        keyboardObserver = nil
-    }
-    displayLink?.invalidate()
-    displayLink = nil
-    animationLayer?.removeAllAnimations()
-    animationLayer?.removeFromSuperlayer()
-    animationLayer = nil
-    settleWorkItem?.cancel()
-    settleWorkItem = nil
-}
-
 @_cdecl("start_safe_area_observer")
 public func start_safe_area_observer() {
-    DispatchQueue.main.async {
-        guard
-            let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-            let window = scene.windows.first(where: { $0.isKeyWindow })
-        else { return }
-
-        // Remove previous monitor if any
-        safeAreaMonitor?.removeFromSuperview()
-
-        // Create a hidden monitor view
-        let monitor = SafeAreaMonitorView(frame: .zero)
-        monitor.isUserInteractionEnabled = false
-        monitor.backgroundColor = .clear
-        monitor.translatesAutoresizingMaskIntoConstraints = false
-        window.addSubview(monitor)
-
-        NSLayoutConstraint.activate([
-            monitor.leadingAnchor.constraint(equalTo: window.leadingAnchor),
-            monitor.trailingAnchor.constraint(equalTo: window.trailingAnchor),
-            monitor.topAnchor.constraint(equalTo: window.topAnchor),
-            monitor.bottomAnchor.constraint(equalTo: window.bottomAnchor),
-        ])
-
-        monitor.onSafeAreaChange = { bottomInset in
-            updateSafeArea(bottomInset)
-        }
-
-        safeAreaMonitor = monitor
-
-        // Initial update
-        updateSafeArea(window.safeAreaInsets.bottom)
+    Task { @MainActor in
+        _startSafeAreaObserverMain()
     }
 }
 
 @_cdecl("stop_safe_area_observer")
 public func stop_safe_area_observer() {
-    DispatchQueue.main.async {
-        safeAreaMonitor?.removeFromSuperview()
-        safeAreaMonitor = nil
+    Task { @MainActor in
+        _stopSafeAreaObserverMain()
     }
+}
+
+@MainActor
+private func _startSafeAreaObserverMain() {
+    guard
+        let scene = UIApplication.shared.connectedScenes.first
+            as? UIWindowScene,
+        let window = scene.windows.first(where: { $0.isKeyWindow })
+    else {
+        return
+    }
+
+    // Remove previous monitor (if any)
+    safeAreaMonitor?.removeFromSuperview()
+    safeAreaMonitor = nil
+
+    // Create and attach monitor view
+    let monitor = SafeAreaMonitorView(frame: .zero)
+    monitor.isUserInteractionEnabled = false
+    monitor.backgroundColor = .clear
+    monitor.translatesAutoresizingMaskIntoConstraints = false
+    window.addSubview(monitor)
+
+    NSLayoutConstraint.activate([
+        monitor.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+        monitor.trailingAnchor.constraint(equalTo: window.trailingAnchor),
+        monitor.topAnchor.constraint(equalTo: window.topAnchor),
+        monitor.bottomAnchor.constraint(equalTo: window.bottomAnchor),
+    ])
+
+    monitor.onSafeAreaChange = { bottomInset in
+        updateSafeArea(bottomInset)
+    }
+
+    safeAreaMonitor = monitor
+
+    // Initial update
+    DispatchQueue.main.async {
+        updateSafeArea(window.safeAreaInsets.bottom)
+    }
+}
+
+@MainActor
+private func _stopSafeAreaObserverMain() {
+    safeAreaMonitor?.removeFromSuperview()
+    safeAreaMonitor = nil
 }
 
 @_cdecl("updateSafeArea")
 public func updateSafeArea(_ newInset: CGFloat) {
-    // guard abs(newInset - lastSafeAreaBottom) > 0.5 else { return }
     lastSafeAreaBottom = newInset
     platform_update_safe_area(Float(newInset))
 }
 
-/// A hidden view that observes changes to the window's safe area insets.
-/// Used to track home indicator height or bottom safe area changes across orientation changes.
+@MainActor
 final class SafeAreaMonitorView: UIView {
 
     /// Callback triggered when the bottom safe area inset changes.
@@ -191,8 +241,11 @@ final class SafeAreaMonitorView: UIView {
 
     /// Cache the last reported inset to avoid duplicate updates.
     private var lastReportedInset: CGFloat = -1
+    private var orientationObserver: NSObjectProtocol?
+    private var statusBarObserver: NSObjectProtocol?
 
     override func didMoveToWindow() {
+        assert(Thread.isMainThread)
         super.didMoveToWindow()
 
         // Recalculate when attached to a new window
@@ -201,8 +254,9 @@ final class SafeAreaMonitorView: UIView {
     }
 
     override func removeFromSuperview() {
-        super.removeFromSuperview()
+        assert(Thread.isMainThread)
         unregisterForOrientationChanges()
+        super.removeFromSuperview()
     }
 
     /// Called automatically whenever safe area insets change.
@@ -219,23 +273,34 @@ final class SafeAreaMonitorView: UIView {
     }
 
     private func registerForOrientationChanges() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleOrientationChange),
-            name: UIDevice.orientationDidChangeNotification,
-            object: nil
-        )
+        let nc = NotificationCenter.default
+        orientationObserverToken = nc.addObserver(
+            forName: UIDevice.orientationDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleOrientationChange()
+        }
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleOrientationChange),
-            name: UIApplication.didChangeStatusBarFrameNotification,
-            object: nil
-        )
+        statusBarObserverToken = nc.addObserver(
+            forName: UIApplication.didChangeStatusBarFrameNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleOrientationChange()
+        }
     }
 
     private func unregisterForOrientationChanges() {
-        NotificationCenter.default.removeObserver(self)
+        let nc = NotificationCenter.default
+        if let t = orientationObserver {
+            nc.removeObserver(t)
+            orientationObserver = nil
+        }
+        if let t = statusBarObserver {
+            nc.removeObserver(t)
+            statusBarObserver = nil
+        }
     }
 
     /// Compare and send only when safe area bottom changes.
@@ -250,7 +315,7 @@ final class SafeAreaMonitorView: UIView {
         guard let window = self.window else { return }
         let newInset = window.safeAreaInsets.bottom
 
-        if abs(newInset - lastReportedInset) > 0.5 {  // avoid tiny floating-point noise
+        if abs(newInset - lastReportedInset) > 0.5 { /// Threshold to avoid noise
             lastReportedInset = newInset
             onSafeAreaChange?(newInset)
         }

--- a/keyboard_insets_mobile/ios/Classes/keyboard_insets.c
+++ b/keyboard_insets_mobile/ios/Classes/keyboard_insets.c
@@ -20,7 +20,10 @@ void start_listening_insets(void) {
 }
 
 void stop_listening_insets(void) {
-    stop_keyboard_observer();
+    if(is_listening_insets){
+        stop_keyboard_observer();
+    }
+    is_listening_insets = false;
 }
 
 void start_listening_safe_area(void){

--- a/keyboard_insets_mobile/pubspec.yaml
+++ b/keyboard_insets_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: keyboard_insets_mobile
 description: "A Flutter plugin that provides real-time keyboard height and visibility state"
-version: 0.1.1
+version: 0.1.2
 
 repository: https://github.com/urbi-ae/keyboard_insets
 homepage: https://github.com/urbi-ae/keyboard_insets

--- a/keyboard_insets_mobile/src/keyboard_insets.c
+++ b/keyboard_insets_mobile/src/keyboard_insets.c
@@ -9,7 +9,15 @@ static float current_inset = -1.0f;
 static float current_target = -1.0f;
 static float max_inset = -1.0f;
 
+static bool lastIsVisible;
+static bool lastIsAnimating;
+
 static bool is_keyboard_animation_enabled = true;
+
+bool is_listening_insets = false;
+bool is_listening_safe_area = false;
+
+void set_inset_listen(bool value) { is_listening_insets = value; }
 
 
 // ---- Keyboard insets ------------------------------------------------------------------
@@ -31,7 +39,10 @@ void unregister_inset_callback(void) { inset_callback = 0; }
 
 void register_state_callback(KeyboardStateUpdateCallback callback) {
     state_callback = callback;
-    start_listening_insets();
+    if(!is_listening_insets){
+        start_listening_insets();
+        is_listening_insets = true;
+    }
 }
 
 void unregister_state_callback(void) { state_callback = 0; }
@@ -71,7 +82,15 @@ void platform_update_inset(float current, float target) {
     }
 
     if (state_callback) {
-        state_callback(is_keyboard_visible(), is_keyboard_animating());
+        bool isVisible = is_keyboard_visible();
+        bool isAnimating = is_keyboard_animating();
+        
+        if(lastIsVisible != isVisible||lastIsAnimating != isAnimating){
+            state_callback(isVisible, isAnimating);
+            lastIsVisible = isVisible;
+            lastIsAnimating = isAnimating;
+        }
+
     }
 }
 
@@ -82,12 +101,18 @@ void stop_listening_safe_area(void);
 
 void register_safe_area_inset_callback(SafeAreaInsetUpdateCallback callback) {
     safe_area_callback = callback;
-    start_listening_safe_area();
+    if(!is_listening_safe_area){
+        start_listening_safe_area();
+        is_listening_safe_area = true;
+    }
 }
 
 void unregister_safe_area_inset_callback(void) { 
     safe_area_callback = 0;
-    stop_listening_safe_area();
+    if(is_listening_safe_area){
+        stop_listening_safe_area();
+        is_listening_safe_area = false;
+    }
 }
 
 /// Called by platform-specific code

--- a/keyboard_insets_mobile/src/keyboard_insets.h
+++ b/keyboard_insets_mobile/src/keyboard_insets.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <stdbool.h>
 
+extern bool is_listening_insets;
+extern bool is_listening_safe_area;
+
 // Get keyboard height in logical pixels.
 float get_keyboard_height(void);
 
@@ -45,3 +48,6 @@ void stop_listening_insets(void);
 
 // Do not call this function directly, it is called by platform-specific code.
 void platform_set_keyboard_animation(bool isEnabled);
+
+// Do not call this function directly, it is called by platform-specific code.
+void set_inset_listen(bool value);


### PR DESCRIPTION
Wrap public C entry points with `@MainActor` to use Swift concurrency for manipulating UI, and for SafeAreaMonitorView class. This guarantees that UIKit calls happen on the main thread.